### PR TITLE
Adding -fcommon to compilation requirements

### DIFF
--- a/system/Make.sys-semishared
+++ b/system/Make.sys-semishared
@@ -24,7 +24,7 @@ MAKE = make
 # C-preprocessor flags
 CPPFLAGS ?=
 # C-compiler flags
-CFLAGS += -ffast-math -funroll-loops -fPIC -pedantic -Wall
+CFLAGS += -ffast-math -funroll-loops -fPIC -pedantic -Wall -fcommon
 
 CC     = gcc 
 #LDLIB  = -ldl

--- a/system/Make.sys-shared
+++ b/system/Make.sys-shared
@@ -19,7 +19,7 @@ MAKE = make
 # C-preprocessor flags
 CPPFLAGS ?=
 # C-compiler flags
-CFLAGS += -ffast-math -funroll-loops -fPIC -pedantic -Wall
+CFLAGS += -ffast-math -funroll-loops -fPIC -pedantic -Wall -fcommon
 
 CC     = gcc 
 #LDLIB  = -ldl

--- a/system/Make.sys-static
+++ b/system/Make.sys-static
@@ -22,7 +22,7 @@ MAKE   = make
 # C-preprocessor flags
 CPPFLAGS =
 # C-compiler flags
-CFLAGS  = -static -ffast-math -funroll-loops -pedantic -Wall 
+CFLAGS  = -static -ffast-math -funroll-loops -pedantic -Wall -fcommon
 LDFLAGS = -static 
 LDLIB   = -ldl -lpthread -lz
 MATH    = -lm


### PR DESCRIPTION
Here's an appropriate location for changing the CFLAGS for compilation. I've done so in all the cases I can imagine it having an impact on; I have only tested the shared case as this is what is needed for my case, but this is likely needed for static and semi-shared as well.